### PR TITLE
Add support force disable sco enhanced sync commands

### DIFF
--- a/device/src/controller.cc
+++ b/device/src/controller.cc
@@ -22,6 +22,7 @@
 
 #include <base/logging.h>
 
+#include "bt_target.h"
 #include "bt_types.h"
 #include "btcore/include/event_mask.h"
 #include "btcore/include/module.h"
@@ -370,12 +371,20 @@ static bool supports_master_slave_role_switch(void) {
 
 static bool supports_enhanced_setup_synchronous_connection(void) {
   assert(readable);
+#if (BTM_SCO_ENHANCED_SYNC_DISABLED == TRUE)
+  return false;
+#else
   return HCI_ENH_SETUP_SYNCH_CONN_SUPPORTED(supported_commands);
+#endif
 }
 
 static bool supports_enhanced_accept_synchronous_connection(void) {
   assert(readable);
+#if (BTM_SCO_ENHANCED_SYNC_DISABLED == TRUE)
+  return false;
+#else
   return HCI_ENH_ACCEPT_SYNCH_CONN_SUPPORTED(supported_commands);
+#endif
 }
 
 static bool supports_ble(void) {

--- a/internal_include/bt_target.h
+++ b/internal_include/bt_target.h
@@ -287,6 +287,11 @@
 #define BTM_DISC_DURING_RS TRUE
 #endif
 
+/* Disables Sco Enhanced Absent on pre-Oreo bluetooth Firmware */
+#ifndef BTM_SCO_ENHANCED_SYNC_DISABLED
+#define BTM_SCO_ENHANCED_SYNC_DISABLED FALSE
+#endif
+
 /**************************
  * Initial SCO TX credit
  ************************/


### PR DESCRIPTION
Disables Sco Enhanced Absent on pre-Oreo bluetooth Firmware